### PR TITLE
feat: add support for uv and uvx python mcp server detection for pinn…

### DIFF
--- a/__tests__/__fixtures__/version-detection-test.json
+++ b/__tests__/__fixtures__/version-detection-test.json
@@ -23,6 +23,74 @@
     "explicit-latest": {
       "command": "npx",
       "args": ["package@latest"]
+    },
+    "sqlite-pinned-uvx": {
+      "command": "uvx",
+      "args": [
+        "mcp-server-sqlite@0.1.0",
+        "--db-path",
+        "/tmp/test.db"
+      ]
+    },
+    "sqlite-latest-uvx": {
+      "command": "uvx",
+      "args": [
+        "mcp-server-sqlite",
+        "--db-path",
+        "/tmp/test.db"
+      ]
+    },
+    "sqlite-pinned-uv": {
+      "command": "uv",
+      "args": [
+        "--directory",
+        "parent_of_servers_repo/servers/src/sqlite",
+        "run",
+        "mcp-server-sqlite@2.1.0",
+        "--db-path",
+        "~/test.db"
+      ]
+    },
+    "sqlite-latest-uv": {
+      "command": "uv",
+      "args": [
+        "--directory",
+        "parent_of_servers_repo/servers/src/sqlite",
+        "run",
+        "mcp-server-sqlite",
+        "--db-path",
+        "~/test.db"
+      ]
+    },
+    "explicit-latest-uvx": {
+      "command": "uvx",
+      "args": [
+        "mcp-server-sqlite@latest",
+        "--db-path",
+        "/tmp/test.db"
+      ]
+    },
+    "ruff-beta-uvx": {
+      "command": "uvx",
+      "args": [
+        "ruff@0.2.0-beta.1",
+        "--check",
+        "."
+      ]
+    },
+    "simple-uv-run": {
+      "command": "uv",
+      "args": [
+        "run",
+        "mcp-server-sqlite@1.5.0"
+      ]
+    },
+    "regular-npx-for-comparison": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-server-nodejs-api-docs@1.1.3"
+      ]
     }
   }
 }

--- a/__tests__/mcp-config-service.test.ts
+++ b/__tests__/mcp-config-service.test.ts
@@ -410,12 +410,27 @@ describe('MCPConfigService', () => {
           assert.ok(server.name, 'Server should have a name')
           assert.ok(server.command !== undefined, 'Server should have a command')
           
-          // Version info should be added for npx commands
+          // Version info should be added for supported package manager commands
           const npxServers = servers.filter(s => s.command === 'npx')
+          const uvxServers = servers.filter(s => s.command === 'uvx') 
+          const uvServers = servers.filter(s => s.command === 'uv')
+          
           if (npxServers.length > 0) {
             // At least one npx server should have version info
             const hasVersionInfo = npxServers.some(s => s.versionInfo !== undefined)
             assert.ok(hasVersionInfo, 'At least one npx server should have version info')
+          }
+          
+          if (uvxServers.length > 0) {
+            // At least one uvx server should have version info
+            const hasVersionInfo = uvxServers.some(s => s.versionInfo !== undefined)
+            assert.ok(hasVersionInfo, 'At least one uvx server should have version info')
+          }
+          
+          if (uvServers.length > 0) {
+            // At least one uv server should have version info
+            const hasVersionInfo = uvServers.some(s => s.versionInfo !== undefined)
+            assert.ok(hasVersionInfo, 'At least one uv server should have version info')
           }
         }
       } catch (error) {
@@ -436,5 +451,7 @@ describe('MCPConfigService', () => {
       // This is validated by the fact that no errors were thrown during construction
       assert.ok(true, 'Version detection service is properly instantiated')
     })
+
+
   })
 })

--- a/__tests__/mcp-version-detection-service.test.ts
+++ b/__tests__/mcp-version-detection-service.test.ts
@@ -141,39 +141,39 @@ describe('MCPVersionDetectionService', () => {
     })
   })
 
-  describe('extractPackageName', () => {
+  describe('extractNpxPackageName', () => {
     test('should extract package after -y flag', () => {
-      const result = service.extractPackageName(['-y', 'mcp-server-nodejs-api-docs@1.1.3'])
+      const result = service.extractNpxPackageName(['-y', 'mcp-server-nodejs-api-docs@1.1.3'])
       assert.strictEqual(result, 'mcp-server-nodejs-api-docs@1.1.3')
     })
 
     test('should extract package after --yes flag', () => {
-      const result = service.extractPackageName(['--yes', 'mcp-server-nodejs-api-docs'])
+      const result = service.extractNpxPackageName(['--yes', 'mcp-server-nodejs-api-docs'])
       assert.strictEqual(result, 'mcp-server-nodejs-api-docs')
     })
 
     test('should extract first non-option argument', () => {
-      const result = service.extractPackageName(['mcp-server-nodejs-api-docs@1.1.3'])
+      const result = service.extractNpxPackageName(['mcp-server-nodejs-api-docs@1.1.3'])
       assert.strictEqual(result, 'mcp-server-nodejs-api-docs@1.1.3')
     })
 
     test('should return null for invalid args', () => {
-      const result = service.extractPackageName(['-q', '--help'])
+      const result = service.extractNpxPackageName(['-q', '--help'])
       assert.strictEqual(result, null)
     })
 
     test('should return null for empty args', () => {
-      const result = service.extractPackageName([])
+      const result = service.extractNpxPackageName([])
       assert.strictEqual(result, null)
     })
 
     test('should handle complex argument patterns', () => {
-      const result = service.extractPackageName(['-q', '-y', 'package'])
+      const result = service.extractNpxPackageName(['-q', '-y', 'package'])
       assert.strictEqual(result, 'package')
     })
 
     test('should skip over options to find package without flags', () => {
-      const result = service.extractPackageName(['-q', '--registry', 'https://example.com', 'package'])
+      const result = service.extractNpxPackageName(['-q', '--registry', 'https://example.com', 'package'])
       assert.strictEqual(result, 'package')
     })
   })
@@ -285,6 +285,222 @@ describe('MCPVersionDetectionService', () => {
     })
   })
 
+  describe('UVX Command Support', () => {
+    test('should detect pinned version from first argument', () => {
+      const result = service.analyzeServerVersion('uvx', ['mcp-server-sqlite@0.1.0', '--db-path', '/tmp/test.db'])
+      
+      assert.deepStrictEqual(result, {
+        packageName: 'mcp-server-sqlite',
+        version: '0.1.0',
+        isPinned: true,
+        isLatest: false
+      })
+    })
+
+    test('should detect latest version from first argument', () => {
+      const result = service.analyzeServerVersion('uvx', ['mcp-server-sqlite', '--db-path', '/tmp/test.db'])
+      
+      assert.deepStrictEqual(result, {
+        packageName: 'mcp-server-sqlite',
+        version: undefined,
+        isPinned: false,
+        isLatest: true
+      })
+    })
+
+    test('should handle explicit latest version', () => {
+      const result = service.analyzeServerVersion('uvx', ['mcp-server-sqlite@latest', '--db-path', '/tmp/test.db'])
+      
+      assert.deepStrictEqual(result, {
+        packageName: 'mcp-server-sqlite',
+        version: 'latest',
+        isPinned: false,
+        isLatest: true
+      })
+    })
+
+    test('should handle complex version specifiers', () => {
+      const result = service.analyzeServerVersion('uvx', ['mcp-server-sqlite@1.2.3-beta.1', '--db-path', '/tmp/test.db'])
+      
+      assert.deepStrictEqual(result, {
+        packageName: 'mcp-server-sqlite',
+        version: '1.2.3-beta.1',
+        isPinned: true,
+        isLatest: false
+      })
+    })
+
+    test('should return null for empty args', () => {
+      const result = service.analyzeServerVersion('uvx', [])
+      assert.strictEqual(result, null)
+    })
+
+    test('should handle single package argument', () => {
+      const result = service.analyzeServerVersion('uvx', ['mcp-server-sqlite@2.0.0'])
+      
+      assert.deepStrictEqual(result, {
+        packageName: 'mcp-server-sqlite',
+        version: '2.0.0',
+        isPinned: true,
+        isLatest: false
+      })
+    })
+  })
+
+  describe('UV Command Support', () => {
+    test('should detect pinned version after run argument', () => {
+      const result = service.analyzeServerVersion('uv', [
+        '--directory', 
+        'parent_of_servers_repo/servers/src/sqlite',
+        'run',
+        'mcp-server-sqlite@0.1.0',
+        '--db-path',
+        '~/test.db'
+      ])
+      
+      assert.deepStrictEqual(result, {
+        packageName: 'mcp-server-sqlite',
+        version: '0.1.0',
+        isPinned: true,
+        isLatest: false
+      })
+    })
+
+    test('should detect latest version after run argument', () => {
+      const result = service.analyzeServerVersion('uv', [
+        '--directory',
+        'parent_of_servers_repo/servers/src/sqlite', 
+        'run',
+        'mcp-server-sqlite',
+        '--db-path',
+        '~/test.db'
+      ])
+      
+      assert.deepStrictEqual(result, {
+        packageName: 'mcp-server-sqlite',
+        version: undefined,
+        isPinned: false,
+        isLatest: true
+      })
+    })
+
+    test('should return null when run argument not found', () => {
+      const result = service.analyzeServerVersion('uv', [
+        '--directory',
+        'some/path',
+        'install',
+        'mcp-server-sqlite'
+      ])
+      
+      assert.strictEqual(result, null)
+    })
+
+    test('should handle run as first argument', () => {
+      const result = service.analyzeServerVersion('uv', [
+        'run',
+        'mcp-server-sqlite@1.5.0',
+        '--some-option'
+      ])
+      
+      assert.deepStrictEqual(result, {
+        packageName: 'mcp-server-sqlite',
+        version: '1.5.0',
+        isPinned: true,
+        isLatest: false
+      })
+    })
+
+    test('should return null when run is last argument', () => {
+      const result = service.analyzeServerVersion('uv', [
+        '--directory',
+        'some/path',
+        'run'
+      ])
+      
+      assert.strictEqual(result, null)
+    })
+
+    test('should handle explicit latest version after run', () => {
+      const result = service.analyzeServerVersion('uv', [
+        'run',
+        'mcp-server-sqlite@latest'
+      ])
+      
+      assert.deepStrictEqual(result, {
+        packageName: 'mcp-server-sqlite',
+        version: 'latest',
+        isPinned: false,
+        isLatest: true
+      })
+    })
+  })
+
+  describe('extractPackageName method routing', () => {
+    test('should route to npx extractor for npx command', () => {
+      const result = service.extractPackageName('npx', ['-y', 'test-package'])
+      assert.strictEqual(result, 'test-package')
+    })
+
+    test('should route to uvx extractor for uvx command', () => {
+      const result = service.extractPackageName('uvx', ['test-package', '--arg'])
+      assert.strictEqual(result, 'test-package')
+    })
+
+    test('should route to uv extractor for uv command', () => {
+      const result = service.extractPackageName('uv', ['run', 'test-package'])
+      assert.strictEqual(result, 'test-package')
+    })
+
+    test('should return null for unsupported command', () => {
+      const result = service.extractPackageName('pip', ['install', 'test-package'])
+      assert.strictEqual(result, null)
+    })
+  })
+
+  describe('extractUvxPackageName', () => {
+    test('should extract first argument as package name', () => {
+      const result = service.extractUvxPackageName(['mcp-server-sqlite@1.0.0', '--db-path', '/tmp'])
+      assert.strictEqual(result, 'mcp-server-sqlite@1.0.0')
+    })
+
+    test('should return null for empty args', () => {
+      const result = service.extractUvxPackageName([])
+      assert.strictEqual(result, null)
+    })
+
+    test('should return first argument even if it looks like an option', () => {
+      const result = service.extractUvxPackageName(['--help'])
+      assert.strictEqual(result, '--help')
+    })
+  })
+
+  describe('extractUvPackageName', () => {
+    test('should extract package name after run argument', () => {
+      const result = service.extractUvPackageName(['--directory', 'path', 'run', 'test-package', '--arg'])
+      assert.strictEqual(result, 'test-package')
+    })
+
+    test('should return null when run not found', () => {
+      const result = service.extractUvPackageName(['--directory', 'path', 'install', 'test-package'])
+      assert.strictEqual(result, null)
+    })
+
+    test('should return null for empty args', () => {
+      const result = service.extractUvPackageName([])
+      assert.strictEqual(result, null)
+    })
+
+    test('should return null when run is last argument', () => {
+      const result = service.extractUvPackageName(['--directory', 'path', 'run'])
+      assert.strictEqual(result, null)
+    })
+
+    test('should handle run at beginning', () => {
+      const result = service.extractUvPackageName(['run', 'test-package'])
+      assert.strictEqual(result, 'test-package')
+    })
+  })
+
   describe('Edge Cases and Integration Scenarios', () => {
     test('should handle real-world Cursor MCP config scenarios', () => {
       // Test case from the original mcp.json
@@ -303,8 +519,8 @@ describe('MCPVersionDetectionService', () => {
       assert.strictEqual(result, null)
     })
 
-    test('should handle uvx commands gracefully', () => {
-      const result = service.analyzeServerVersion('uvx', ['mcp-server-fetch'])
+    test('should handle unsupported commands gracefully', () => {
+      const result = service.analyzeServerVersion('pip', ['install', 'some-package'])
       assert.strictEqual(result, null)
     })
 


### PR DESCRIPTION
### **User description**
…ed versions

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- Unit tests are expected for all changes. -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation (if required).
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I added a picture of a cute animal cause it's fun


___

### **PR Type**
Enhancement


___

### **Description**
- Add support for `uv` and `uvx` Python package managers

- Extend version detection to Python MCP servers

- Update tests for multi-package manager support

- Add comprehensive documentation for new commands


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["MCPVersionDetectionService"] --> B["extractPackageName()"]
  B --> C["NPX Extractor"]
  B --> D["UVX Extractor"] 
  B --> E["UV Extractor"]
  C --> F["Version Analysis"]
  D --> F
  E --> F
  F --> G["PackageVersionInfo"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mcp-version-detection-service.ts</strong><dd><code>Extend version detection for Python package managers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/services/mcp-version-detection-service.ts

<ul><li>Add support for <code>uvx</code> and <code>uv</code> commands alongside existing <code>npx</code><br> <li> Implement command-specific package name extraction methods<br> <li> Add routing logic to select appropriate extractor based on command<br> <li> Extend version detection to Python package managers</ul>


</details>


  </td>
  <td><a href="https://github.com/lirantal/ls-mcp/pull/106/files#diff-67c7d47d248ea740c3a3345b6df73c8fe9047604c5df74b042491be4516c5f6f">+56/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mcp-version-detection-service.test.ts</strong><dd><code>Add comprehensive tests for Python package managers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

__tests__/mcp-version-detection-service.test.ts

<ul><li>Add comprehensive test suites for UVX and UV command support<br> <li> Rename existing NPX tests for clarity and consistency<br> <li> Add tests for command routing and package extraction methods<br> <li> Include edge cases and integration scenarios</ul>


</details>


  </td>
  <td><a href="https://github.com/lirantal/ls-mcp/pull/106/files#diff-beccf6dbc3b3ccf44af4ed2d9cccc1d937c68959624429a9492180ff8c2863e8">+226/-10</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mcp-config-service.test.ts</strong><dd><code>Update integration tests for multi-package manager support</code></dd></summary>
<hr>

__tests__/mcp-config-service.test.ts

<ul><li>Update integration tests to validate <code>uvx</code> and <code>uv</code> servers<br> <li> Add version info validation for Python package managers<br> <li> Extend existing test coverage for multi-command support</ul>


</details>


  </td>
  <td><a href="https://github.com/lirantal/ls-mcp/pull/106/files#diff-004dacf38b97260992e7f3ed6be114192cd49524b05789930a0caf9d9cbafdce">+18/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>version-detection-test.json</strong><dd><code>Add Python package manager test fixtures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

__tests__/__fixtures__/version-detection-test.json

<ul><li>Add test fixtures for <code>uvx</code> and <code>uv</code> command configurations<br> <li> Include pinned and latest version examples for Python servers<br> <li> Add complex argument patterns and edge cases</ul>


</details>


  </td>
  <td><a href="https://github.com/lirantal/ls-mcp/pull/106/files#diff-15ff39a5cd535d23f601bba6093f6d7c0dbd206e987bbe6f765c36846c08934f">+68/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pinned-version-detection.md</strong><dd><code>Document Python package manager support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/pinned-version-detection.md

<ul><li>Document UVX and UV command detection rules<br> <li> Add configuration examples for Python package managers<br> <li> Update service interface documentation<br> <li> Expand test specification for new commands</ul>


</details>


  </td>
  <td><a href="https://github.com/lirantal/ls-mcp/pull/106/files#diff-d0ad0f600f3f081b55412667a892c8cabd18a1479b8dfa79bbcef1258f76caf7">+138/-9</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

