### PR TITLE
feat: add JSON output option for MCP server configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,18 @@
 npx ls-mcp
 ```
 
+### JSON Output
+
+To output results in JSON format (useful for programmatic consumption):
+
+```bash
+npx ls-mcp --json
+```
+
+This will return a structured JSON object containing:
+- `mcpFiles`: Complete MCP server configurations organized by provider (only includes providers with configured servers)
+- `summary`: Statistics including total servers, running servers, credential warnings, and transport breakdown
+
 ### Debug Mode
 
 To enable verbose debugging output, set the `NODE_DEBUG` environment variable:


### PR DESCRIPTION
### **User description**
- Introduced a `--json` flag to the CLI for outputting results in JSON format.
- Updated README to document the new JSON output feature and its structure.
- Adjusted CLI behavior to conditionally render output based on the presence of the `--json` flag.

## Description

<!--- Describe your changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

When used for running the script on multiple computers or as part of other script.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I added a picture of a cute animal cause it's fun


___

### **PR Type**
Enhancement


___

### **Description**
- Added `--json` flag for structured JSON output

- Conditional rendering based on output format

- Updated documentation with JSON usage examples

- Enhanced programmatic integration capabilities


___

### Diagram Walkthrough


```mermaid
flowchart LR
  CLI["CLI Entry Point"] -- "Parse --json flag" --> ARGS["Command Args"]
  ARGS -- "JSON mode?" --> COND{"Output Mode"}
  COND -- "Console" --> RENDER["Render Service"]
  COND -- "JSON" --> JSON["JSON Output"]
  RENDER --> CONSOLE["Console Display"]
  JSON --> STDOUT["Structured JSON"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cli.ts</strong><dd><code>Implement JSON output functionality</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/bin/cli.ts

<ul><li>Added command-line argument parsing for <code>--json</code> flag<br> <li> Implemented conditional rendering logic based on output mode<br> <li> Created structured JSON output with filtered MCP files and summary <br>statistics<br> <li> Suppressed console output when in JSON mode</ul>


</details>


  </td>
  <td><a href="https://github.com/lirantal/ls-mcp/pull/114/files#diff-a56a5f26a66e5e05f72d332be2e5af52fce4e5ffe8b748ad5f0325399fc1fe9a">+40/-17</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document JSON output feature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Added JSON Output section with usage examples<br> <li> Documented JSON structure containing <code>mcpFiles</code> and <code>summary</code> fields<br> <li> Explained programmatic consumption benefits</ul>


</details>


  </td>
  <td><a href="https://github.com/lirantal/ls-mcp/pull/114/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+12/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

