### PR TITLE
fix: resolve TypeScript imports in ESLint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -28,6 +28,9 @@ export default defineConfig([
       'n/no-process-exit': 'off',
       'n/no-unsupported-features': 'off',
       'n/no-unpublished-require': 'off',
+      'n/no-missing-import': ['error', {
+        typescriptExtensionMap: [['.ts', '.js'], ['.tsx', '.js']]
+      }],
       'security/detect-non-literal-fs-filename': 'off',
       'security/detect-unsafe-regex': 'error',
       'security/detect-buffer-noassert': 'error',


### PR DESCRIPTION
The grouped dev-dependency update raises eslint-plugin-n to v18, whose no-missing-import rule needs the repository’s .js-to-.ts import mapping. Configure the supported TypeScript extension map so lint accepts NodeNext TypeScript imports. Verified with npm ci and npm run lint in Node 24.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Configure `eslint-plugin-n` to resolve NodeNext TypeScript imports by adding a `typescriptExtensionMap` to `n/no-missing-import`. Prevents false missing-import errors for `.ts`/`.tsx` (mapped to `.js`) and keeps linting green on Node 24.

<sup>Written for commit 2472a8b312e161029e8af440cf8d946869c7a91f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lirantal/ls-mcp/pull/187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

